### PR TITLE
Update async to fix CVE-2021-43138

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,10 +13,10 @@
     "url": "git://github.com/nearinfinity/node-cmdparser.git"
   },
   "engines": {
-    "node": "*"
+    "node": ">=4"
   },
   "dependencies": {
-    "async": "~0.1.22"
+    "async": "^3.2.3"
   },
   "devDependencies": {
     "mocha": "^9.2.2",

--- a/package.json
+++ b/package.json
@@ -19,10 +19,11 @@
     "async": "~0.1.22"
   },
   "devDependencies": {
-    "nodeunit": "~0.7.4"
+    "mocha": "^9.2.2",
+    "chai": "^4.3.6"
   },
   "scripts": {
-    "test": "./node_modules/nodeunit/bin/nodeunit test"
+    "test": "mocha test"
   },
   "main": "./parser.js"
 }

--- a/parser.js
+++ b/parser.js
@@ -11,7 +11,7 @@ var CmdParser = module.exports = function (commands, completers) {
 
 CmdParser.prototype.parse = function (str, callback) {
   var matches = [];
-  async.forEach(this._commands, function (cmd, cb) {
+  async.each(this._commands, function (cmd, cb) {
     cmd.parse(str, function (err, r) {
       if (r) {
         matches.push(r);
@@ -35,7 +35,7 @@ CmdParser.prototype.parse = function (str, callback) {
 CmdParser.prototype.completer = function (str, callback) {
   var self = this;
   var matches = [];
-  async.forEach(this._commands, function (cmd, cb) {
+  async.each(this._commands, function (cmd, cb) {
     cmd.completer(str, self._completers, function (err, r) {
       if (r) {
         matches.push(r);
@@ -250,7 +250,7 @@ function parseAll(state, parts, callback) {
     console.log('parts', state.cmd, JSON.stringify(parts, null, '  '));
   }
 
-  async.forEachSeries(parts, function (part, callback) {
+  async.eachSeries(parts, function (part, callback) {
     if (state.completer) {
       return callback();
     }
@@ -346,7 +346,9 @@ function parseOptionalParameters(state, part, callback) {
     var saveResults = state.result;
     state.result = {params: {}};
     async.whilst(
-      function () { return !isEndOfString(state); },
+      function (cbt) {
+        cbt(null, !isEndOfString(state));
+        },
       function (cb) {
         parseAll(state, part.parts, function (err) {
           if (state.debug) {

--- a/parser.js
+++ b/parser.js
@@ -23,7 +23,7 @@ CmdParser.prototype.parse = function (str, callback) {
       return callback(err);
     }
     if (matches.length === 0) {
-      return callback();
+      return callback(null);
     }
     if (matches.length === 1) {
       return callback(null, matches[0]);
@@ -47,7 +47,7 @@ CmdParser.prototype.completer = function (str, callback) {
       return callback(err);
     }
     if (matches.length === 0) {
-      return callback();
+      return callback(null);
     }
     var bestPartial = matches[0].partial; // todo find a better way
     var results = [

--- a/test/completerTest.js
+++ b/test/completerTest.js
@@ -1,50 +1,52 @@
 'use strict';
 
-var CmdParser = require('../parser');
+const CmdParser = require('../parser');
+const expect = require('chai').expect;
 
-exports.completerTest = {
-  "single word command": function (test) {
-    var cmdparser = new CmdParser([
+describe('completer tests', function() {
+
+  it('single word command', function (done) {
+    const cmdparser = new CmdParser([
       "test"
     ]);
     cmdparser.completer("te", function (err, results) {
-      test.equal(err, null);
-      test.deepEqual(results, [
+      expect(err, 'no error returned').to.be.null;
+      expect(results).to.deep.equal([
         ["test "],
         "te"
-      ]);
-      test.done();
+      ], 'command was parsed');
+      done();
     });
-  },
+  });
 
-  "single word command, multiple matches": function (test) {
-    var cmdparser = new CmdParser([
+  it('single word command, multiple matches', function (done) {
+    const cmdparser = new CmdParser([
       "test1",
       "test2"
     ]);
     cmdparser.completer("te", function (err, results) {
-      test.equal(err, null);
-      test.deepEqual(results, [
+      expect(err, 'no error returned').to.be.null;
+      expect(results).to.deep.equal([
         ["test1 ", "test2 "],
         "te"
-      ]);
-      test.done();
+      ], 'command was parsed');
+      done();
     });
-  },
+  });
 
-  "single word command, no match": function (test) {
-    var cmdparser = new CmdParser([
+  it('single word command, no match', function (done) {
+    const cmdparser = new CmdParser([
       "test"
     ]);
     cmdparser.completer("bad", function (err, results) {
-      test.equal(err, null);
-      test.equal(results, null);
-      test.done();
+      expect(err, 'no error returned').to.be.null;
+      expect(results, 'no command found by parser').to.be.undefined;
+      done();
     });
-  },
+  });
 
-  "one required parameter": function (test) {
-    var cmdparser = new CmdParser([
+  it('one required parameter', function (done) {
+    const cmdparser = new CmdParser([
       "test param1"
     ], {
       param1: function (partial, callback) {
@@ -54,26 +56,26 @@ exports.completerTest = {
       }
     });
     cmdparser.completer("test val", function (err, results) {
-      test.equal(err, null);
-      test.deepEqual(results, [
+      expect(err, 'no error returned').to.be.null;
+      expect(results).to.deep.equal([
         ["val1", "val2", "val3"],
         "val"
-      ]);
-      test.done();
+      ], 'command was parsed');
+      done();
     });
-  },
+  });
 
-  "literal": function (test) {
-    var cmdparser = new CmdParser([
+  it('literal', function (done) {
+    const cmdparser = new CmdParser([
       "test [TEST]"
     ]);
     cmdparser.completer("test T", function (err, results) {
-      test.equal(err, null);
-      test.deepEqual(results, [
+      expect(err, 'no error returned').to.be.null;
+      expect(results).to.deep.equal([
         ["TEST"],
         "T"
-      ]);
-      test.done();
+      ], 'command was parsed');
+      done();
     });
-  }
-};
+  });
+});

--- a/test/parserTest.js
+++ b/test/parserTest.js
@@ -1,198 +1,217 @@
 'use strict';
 
-var CmdParser = require('../parser');
+const CmdParser = require('../parser');
+const expect = require('chai').expect;
 
-exports.parserTest = {
-  "single word command": function (test) {
-    var cmdparser = new CmdParser([
+describe('parser tests', function() {
+
+  it('single word command', function (done) {
+    const cmdparser = new CmdParser([
       "test"
     ]);
     cmdparser.parse("test", function (err, results) {
-      test.equal(results.name, "test");
-      test.done();
+      expect(err, 'no error returned').to.be.null;
+      expect(results.name).to.equal("test");
+      done();
     });
-  },
+  });
 
-  "single word command, no match": function (test) {
-    var cmdparser = new CmdParser([
+  it('single word command, no match', function (done) {
+    const cmdparser = new CmdParser([
       "test"
     ]);
     cmdparser.parse("bad", function (err, results) {
-      test.equal(results, null);
-      test.done();
+      expect(err, 'no error returned').to.be.null;
+      expect(results).to.be.undefined;
+      done();
     });
-  },
+  });
 
-  "one required parameter": function (test) {
-    var cmdparser = new CmdParser([
+  it('one required parameter', function (done) {
+    const cmdparser = new CmdParser([
       "test param1"
     ]);
     cmdparser.parse("test val", function (err, results) {
-      test.equal(results.name, "test");
-      test.equal(results.params.param1, "val");
-      test.done();
+      expect(err, 'no error returned').to.be.null;
+      expect(results.name).to.equal("test");
+      expect(results.params.param1).to.equal("val", 'param 1 matches');
+      done();
     });
-  },
+  });
 
-  "two required parameters": function (test) {
-    var cmdparser = new CmdParser([
+  it('two required parameters', function (done) {
+    const cmdparser = new CmdParser([
       "test param1 param2"
     ]);
     cmdparser.parse("test val1 val2", function (err, results) {
-      test.equal(results.name, "test");
-      test.equal(results.params.param1, "val1");
-      test.equal(results.params.param2, "val2");
-      test.done();
+      expect(err, 'no error returned').to.be.null;
+      expect(results.name).to.equal("test");
+      expect(results.params.param1).to.equal("val1", 'param 1 matches');
+      expect(results.params.param2).to.equal("val2", 'param 2 matches');
+      done();
     });
-  },
+  });
 
-  "ignore the whitespace": function (test) {
-    var cmdparser = new CmdParser([
+  it('ignore the whitespace', function (done) {
+    const cmdparser = new CmdParser([
       "test param1 param2"
     ]);
     cmdparser.parse("test \t val1 \t val2", function (err, results) {
-      test.equal(results.name, "test");
-      test.equal(results.params.param1, "val1");
-      test.equal(results.params.param2, "val2");
-      test.done();
+      expect(err, 'no error returned').to.be.null;
+      expect(results.name).to.equal("test");
+      expect(results.params.param1).to.equal("val1", 'param 1 matches');
+      expect(results.params.param2).to.equal("val2", 'param 2 matches');
+      done();
     });
-  },
+  });
 
-  "one optional parameter, not given": function (test) {
-    var cmdparser = new CmdParser([
+  it('one optional parameter, not given', function (done) {
+    const cmdparser = new CmdParser([
       "test [param1]"
     ]);
     cmdparser.parse("test", function (err, results) {
-      test.equal(results.name, "test");
-      test.equal(results.params.param1, null);
-      test.done();
+      expect(err, 'no error returned').to.be.null;
+      expect(results.name).to.equal("test");
+      expect(results.params.param1, 'param 1 is not set').to.be.undefined;
+      done();
     });
-  },
+  });
 
-  "one optional parameter, given": function (test) {
-    var cmdparser = new CmdParser([
+  it('one optional parameter, given', function (done) {
+    const cmdparser = new CmdParser([
       "test [param1]"
     ]);
     cmdparser.parse("test val", function (err, results) {
-      test.equal(results.name, "test");
-      test.equal(results.params.param1, "val");
-      test.done();
+      expect(err, 'no error returned').to.be.null;
+      expect(results.name).to.equal("test");
+      expect(results.params.param1).to.equal("val", 'param 1 matches');
+      done();
     });
-  },
+  });
 
-  "optional parameter multivalue": function (test) {
-    var cmdparser = new CmdParser([
+  it('optional parameter multivalue', function (done) {
+    const cmdparser = new CmdParser([
       "test [param1 param2]"
     ]);
     cmdparser.parse("test val1 val2", function (err, results) {
-      test.equal(results.name, "test");
-      test.equal(results.params.param1, "val1");
-      test.equal(results.params.param2, "val2");
-      test.done();
+      expect(err, 'no error returned').to.be.null;
+      expect(results.name).to.equal("test");
+      expect(results.params.param1).to.equal("val1", 'param 1 matches');
+      expect(results.params.param2).to.equal("val2", 'param 2 matches');
+      done();
     });
-  },
+  });
 
-  "optional parameter literal string, match": function (test) {
-    var cmdparser = new CmdParser([
+  it('optional parameter literal string, match', function (done) {
+    const cmdparser = new CmdParser([
       'test [TEST]'
     ]);
     cmdparser.parse("test test", function (err, results) {
-      test.equal(results.name, "test");
-      test.equal(results.params.TEST, true);
-      test.done();
+      expect(err, 'no error returned').to.be.null;
+      expect(results.name).to.equal("test");
+      expect(results.params.TEST, 'param TEST is true').to.be.true;
+      done();
     });
-  },
+  });
 
-  "optional parameter literal string, no match": function (test) {
-    var cmdparser = new CmdParser([
+  it('optional parameter literal string, no match', function (done) {
+    const cmdparser = new CmdParser([
       'test [TEST]'
     ]);
     cmdparser.parse("test", function (err, results) {
-      test.equal(results, null);
-      test.done();
+      expect(err, 'no error returned').to.be.null;
+      expect(results).to.be.undefined;
+      done();
     });
-  },
+  });
 
-  "multiple optional with literal string, first": function (test) {
-    var cmdparser = new CmdParser([
+  it('multiple optional with literal string, first', function (done) {
+    const cmdparser = new CmdParser([
       'test [TEST1] [TEST2]'
     ]);
     cmdparser.parse("test test1", function (err, results) {
-      test.equal(results.name, "test");
-      test.equal(results.params.TEST1, true);
-      test.equal(results.params.TEST2, false);
-      test.done();
+      expect(err, 'no error returned').to.be.null;
+      expect(results.name).to.equal("test");
+      expect(results.params.TEST1, 'param TEST1 is true').to.be.true;
+      expect(results.params.TEST2, 'param TEST2 is false').to.be.false;
+      done();
     });
-  },
+  });
 
-  "multiple optional with literal string, second": function (test) {
-    var cmdparser = new CmdParser([
+  it('multiple optional with literal string, second', function (done) {
+    const cmdparser = new CmdParser([
       'test [TEST1] [TEST2]'
     ]);
     cmdparser.parse("test test2", function (err, results) {
-      test.equal(results.name, "test");
-      test.equal(results.params.TEST1, false);
-      test.equal(results.params.TEST2, true);
-      test.done();
+      expect(err, 'no error returned').to.be.null;
+      expect(results.name).to.equal("test");
+      expect(results.params.TEST1, 'param TEST1 is false').to.be.false;
+      expect(results.params.TEST2, 'param TEST2 is true').to.be.true;
+      done();
     });
-  },
+  });
 
-  "multiple optional with literal string and params": function (test) {
-    var cmdparser = new CmdParser([
+  it('multiple optional with literal string and params', function (done) {
+    const cmdparser = new CmdParser([
       'test [TEST1 param1] [TEST2 param2]'
     ]);
     cmdparser.parse("test test1 val1", function (err, results) {
-      test.equal(results.name, "test");
-      test.equal(results.params.TEST1, true);
-      test.equal(results.params.param1, 'val1');
-      test.equal(results.params.TEST2, false);
-      test.done();
+      expect(err, 'no error returned').to.be.null;
+      expect(results.name).to.equal("test");
+      expect(results.params.TEST1, 'param TEST1 is true').to.be.true;
+      expect(results.params.param1).to.equal("val1", 'param 1 matches');
+      expect(results.params.TEST2, 'param TEST2 is false').to.be.false;
+      done();
     });
-  },
+  });
 
-  "repeat single parmeter": function (test) {
-    var cmdparser = new CmdParser([
+  it('repeat single parameter', function (done) {
+    const cmdparser = new CmdParser([
       'test [param1 ...]'
     ]);
     cmdparser.parse("test val1 val2", function (err, results) {
-      test.equal(results.name, "test");
-      test.equal(results.params.param1.length, 2);
-      test.equal(results.params.param1[0], 'val1');
-      test.equal(results.params.param1[1], 'val2');
-      test.done();
+      expect(err, 'no error returned').to.be.null;
+      expect(results.name).to.equal("test");
+      expect(results.params.param1).to.be.a('Array').and.have.length(2);
+      expect(results.params.param1[0]).to.equal("val1", 'param1[0] matches');
+      expect(results.params.param1[1]).to.equal("val2", 'param1[1] matches');
+      done();
     });
-  },
+  });
 
-  "repeat single parmeter, not given": function (test) {
-    var cmdparser = new CmdParser([
+  it('repeat single parameter, not given', function (done) {
+    const cmdparser = new CmdParser([
       'test [param1 ...]'
     ]);
     cmdparser.parse("test", function (err, results) {
-      test.equal(results.name, "test");
-      test.equal(results.params.param1, null);
-      test.done();
+      expect(err, 'no error returned').to.be.null;
+      expect(results.name).to.equal("test");
+      expect(results.params.param1, 'param1 not set').to.be.undefined;
+      done();
     });
-  },
+  });
 
-  "quotes": function (test) {
-    var cmdparser = new CmdParser([
+  it('quotes', function (done) {
+    const cmdparser = new CmdParser([
       'test param1'
     ]);
     cmdparser.parse('test "hello world"', function (err, results) {
-      test.equal(results.name, "test");
-      test.equal(results.params.param1, "hello world");
-      test.done();
+      expect(err, 'no error returned').to.be.null;
+      expect(results.name).to.equal("test");
+      expect(results.params.param1).to.equal("hello world", 'param 1 matches');
+      done();
     });
-  },
+  });
 
-  "quotes with escapes": function (test) {
-    var cmdparser = new CmdParser([
+  it('quotes with escapes', function (done) {
+    const cmdparser = new CmdParser([
       'test param1'
     ]);
     cmdparser.parse('test "hello \\" world"', function (err, results) {
-      test.equal(results.name, "test");
-      test.equal(results.params.param1, 'hello \" world');
-      test.done();
+      expect(err, 'no error returned').to.be.null;
+      expect(results.name).to.equal("test");
+      expect(results.params.param1).to.equal('hello \" world', 'param 1 matches');
+      done();
     });
-  }
-};
+  });
+});

--- a/test/redisTest.js
+++ b/test/redisTest.js
@@ -1,10 +1,11 @@
 'use strict';
 
-var CmdParser = require('../parser');
+const CmdParser = require('../parser');
+const expect = require('chai').expect;
 
-exports.redisTest = {
-  setUp: function (done) {
-    this.cmdparser = new CmdParser([
+describe('redis tests', function() {
+
+  const cmdparser = new CmdParser([
       "APPEND key value",
       "AUTH password",
       "BGREWRITEAOF",
@@ -149,98 +150,96 @@ exports.redisTest = {
       "ZUNIONSTORE destination numkeys key [key ...] [WEIGHTS weight [weight ...]] [AGGREGATE SUM|MIN|MAX]"
     ], {
       key: function (partial, callback) {
-        var r = ['user:1', 'user:2', 'item:1', 'item:2', 'item:3', 'item:4']
+        const r = ['user:1', 'user:2', 'item:1', 'item:2', 'item:3', 'item:4']
           .filter(function (item) { return item.toLowerCase().indexOf(partial.toLowerCase()) === 0; });
         callback(null, r);
       }
     });
-    done();
-  },
 
-  "DEL completer": function (test) {
-    this.cmdparser.completer("del user", function (err, results) {
-      test.deepEqual(results, [
+  it('DEL completer', function (done) {
+    cmdparser.completer("del user", function (err, results) {
+      expect(err, 'no error returned').to.be.null;
+      expect(results).to.deep.equal([
         ["user:1", "user:2"],
         "user"
-      ]);
-      test.done();
+      ], 'command was parsed');
+      done();
     });
-  },
+  });
 
-  "CONFIG GET completer": function (test) {
-    this.cmdparser.completer("CONFIG GE", function (err, results) {
-      test.deepEqual(results, [
+  it('CONFIG GET completer', function (done) {
+    cmdparser.completer("CONFIG GE", function (err, results) {
+      expect(err, 'no error returned').to.be.null;
+      expect(results).to.deep.equal([
         ["GET"],
         "GE"
-      ]);
-      test.done();
+      ], 'command was parsed');
+      done();
     });
-  },
+  });
 
-  "BLPOP completer": function (test) {
-    this.cmdparser.completer("BLPOP user", function (err, results) {
-      test.deepEqual(results, [
+  it('BLPOP completer', function (done) {
+    cmdparser.completer("BLPOP user", function (err, results) {
+      expect(err, 'no error returned').to.be.null;
+      expect(results).to.deep.equal([
         ["user:1", "user:2"],
         "user"
-      ]);
-
-      test.done();
+      ], 'command was parsed');
+      done();
     });
-  },
+  });
 
-  "BLPOP parser": function (test) {
-    this.cmdparser.parse("BLPOP user:1 4", function (err, results) {
-      test.deepEqual(results, {
+  it('BLPOP parser', function (done) {
+    cmdparser.parse("BLPOP user:1 4", function (err, results) {
+      expect(err, 'no error returned').to.be.null;
+      expect(results).to.deep.equal({
         name: 'BLPOP',
         params: {
           key: 'user:1',
           timeout: 4
         }
-      });
-
-      test.done();
+      }, 'command was parsed');
+      done();
     });
-  },
+  });
 
-  "ZRANGE completion": function (test) {
-    this.cmdparser.completer("ZRANGE ", function (err, results) {
-      test.equal(err, null);
-      test.deepEqual(results, [
+  it('ZRANGE completion', function (done) {
+    cmdparser.completer("ZRANGE ", function (err, results) {
+      expect(err, 'no error returned').to.be.null;
+      expect(results).to.deep.equal([
         [ 'user:1', 'user:2', 'item:1', 'item:2', 'item:3', 'item:4' ],
         ''
-      ]);
-      test.done();
+      ], 'command was parsed');
+      done();
     });
-  },
+  });
 
-  "LINSERT completer": function (test) {
-    this.cmdparser.completer("LINSERT user:1 ", function (err, results) {
-      test.equal(err, null);
-      test.deepEqual(results, [
+  it('LINSERT completer', function (done) {
+    cmdparser.completer("LINSERT user:1 ", function (err, results) {
+      expect(err, 'no error returned').to.be.null;
+      expect(results).to.deep.equal([
         ["BEFORE", "AFTER"],
         ""
-      ]);
-
-      test.done();
+      ], 'command was parsed');
+      done();
     });
-  },
+  });
 
-  "LINSERT completer hint": function (test) {
-    this.cmdparser.completer("LINSERT user:1 B", function (err, results) {
-      test.equal(err, null);
-      test.deepEqual(results, [
+  it('LINSERT completer hint', function (done) {
+    cmdparser.completer("LINSERT user:1 B", function (err, results) {
+      expect(err, 'no error returned').to.be.null;
+      expect(results).to.deep.equal([
         ["BEFORE"],
         "B"
-      ]);
-
-      test.done();
+      ], 'command was parsed');
+      done();
     });
-  },
+  });
 
-  "LINSERT parser": function (test) {
-    this.cmdparser.parse("LINSERT user:1 BEFORE a b", function (err, results) {
-      test.equal(err, null);
-      test.deepEqual(results, {
+  it('LINSERT parser', function (done) {
+    cmdparser.parse("LINSERT user:1 BEFORE a b", function (err, results) {
+      expect(err, 'no error returned').to.be.null;
+      expect(results).to.deep.equal({
         name: 'LINSERT',
         params: {
           key: 'user:1',
@@ -249,9 +248,8 @@ exports.redisTest = {
           pivot: 'a',
           value: 'b'
         }
-      });
-
-      test.done();
+      }, 'command was parsed');
+      done();
     });
-  }
-};
+  });
+});


### PR DESCRIPTION
The "async" library version used in current package version 0.0.3 has an prototype pollution (CVE-2021-43138) vulnerability fix on latest version only.
This PR updates "async" to latest 3.2.3.

A small fix is added too where the library behavior differed in the value returned for the "error" object. Most time its explicit `null`, only when no match was found it returned `undefined` before.

As "nodeunit" does not work with current node versions anymore (uses some deprecated calls inside "nodeunit") i changed all tests to use "mocha".